### PR TITLE
Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1739053031,
+        "narHash": "sha256-LrMDRuwAlRFD2T4MgBSRd1s2VtOE+Vl1oMCNu3RpPE0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "112e6591b2d6313b1bd05a80a754a8ee42432a7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": []
+      },
+      "locked": {
+        "lastModified": 1739514825,
+        "narHash": "sha256-zqKZRVUDB7OraQlXcm1T303e3X67DP0D3tKFvC1rKRM=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "37c2259ca7cc5775042f13899ee62f3c4ee032e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1739451785,
+        "narHash": "sha256-3ebRdThRic9bHMuNi2IAA/ek9b32bsy8F5R4SvGTIog=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1128e89fd5e11bb25aedbfc287733c6502202ea9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -122,6 +122,7 @@
               type = types.port;
               description = "Port that vertd should listen to";
               example = 8080;
+              default = 24153;
             };
           };
 
@@ -131,6 +132,8 @@
               isSystemUser = true;
             };
             users.groups.vertd = { };
+
+            environment.sessionVariables.PORT = cfg.port;
 
             systemd.services.vertd = {
               description = "vertd video converter service";
@@ -145,6 +148,7 @@
                 ExecStart = lib.getExe self.packages.${pkgs.system}.default;
                 StateDirectory = "vertd";
                 WorkingDirectory = "/var/lib/vertd";
+                Environment = "PORT=${builtins.toString cfg.port}";
               };
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -130,7 +130,7 @@
               description = "vertd video converter service";
               wantedBy = [ "multi-user.target" ];
               after = [ "network.target" ];
-              script = lib.getExe self.packages.${pkgs.system}.default;
+              path = [ pkgs.ffmpeg ];
               serviceConfig = {
                 User = "vertd";
                 Group = "vertd";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,191 @@
+{
+  description = "Build a cargo project";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    crane.url = "github:ipetkov/crane";
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-analyzer-src.follows = "";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      crane,
+      fenix,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        inherit (pkgs) lib;
+
+        craneLib = crane.mkLib pkgs;
+        src = craneLib.cleanCargoSource ./.;
+
+        commonArgs = {
+          inherit src;
+          strictDeps = true;
+        };
+
+        craneLibLLvmTools = craneLib.overrideToolchain (
+          fenix.packages.${system}.complete.withComponents [
+            "cargo"
+            "llvm-tools"
+            "rustc"
+          ]
+        );
+
+        # Build *just* the cargo dependencies, so we can reuse
+        # all of that work (e.g. via cachix) when running in CI
+        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+        # Build the actual crate itself, reusing the dependency
+        # artifacts from above.
+        vertd = craneLib.buildPackage (
+          commonArgs
+          // {
+            inherit cargoArtifacts;
+
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+
+            postFixup = ''
+              wrapProgram $out/bin/vertd --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ pkgs.libGL ]}"
+            '';
+
+            meta = {
+              description = "VERT's solution to crappy video conversion services.";
+              homepage = "https://github.com/vert-sh/vertd";
+              license = lib.licenses.gpl3;
+              platforms = lib.platforms.linux;
+              maintainers = with lib.maintainers; [ justdeeevin ];
+              mainProgram = "vertd";
+            };
+          }
+        );
+      in
+      {
+        checks = {
+          # Build the crate as part of `nix flake check` for convenience
+          inherit vertd;
+
+          # Run clippy (and deny all warnings) on the crate source,
+          # again, reusing the dependency artifacts from above.
+          #
+          # Note that this is done as a separate derivation so that
+          # we can block the CI if there are issues here, but not
+          # prevent downstream consumers from building our crate by itself.
+          vertd-clippy = craneLib.cargoClippy (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+            }
+          );
+
+          vertd-doc = craneLib.cargoDoc (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+            }
+          );
+
+          # Check formatting
+          vertd-fmt = craneLib.cargoFmt {
+            inherit src;
+          };
+
+          vertd-toml-fmt = craneLib.taploFmt {
+            src = pkgs.lib.sources.sourceFilesBySuffices src [ ".toml" ];
+            # taplo arguments can be further customized below as needed
+            # taploExtraArgs = "--config ./taplo.toml";
+          };
+
+          # Run tests with cargo-nextest
+          # Consider setting `doCheck = false` on `vertd` if you do not want
+          # the tests to run twice
+          vertd-nextest = craneLib.cargoNextest (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              partitions = 1;
+              partitionType = "count";
+              cargoNextestPartitionsExtraArgs = "--no-tests=pass";
+            }
+          );
+        };
+
+        packages =
+          {
+            default = vertd;
+          }
+          // lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
+            vertd-llvm-coverage = craneLibLLvmTools.cargoLlvmCov (
+              commonArgs
+              // {
+                inherit cargoArtifacts;
+              }
+            );
+          };
+
+        apps.default = flake-utils.lib.mkApp {
+          drv = vertd;
+        };
+
+        devShells.default = craneLib.devShell {
+          checks = self.checks.${system};
+        };
+
+        nixosModules.default =
+          { config, ... }:
+          let
+            inherit (lib)
+              mkEnableOption
+              mkIf
+              mkOption
+              types
+              ;
+
+            cfg = config.services.vertd;
+          in
+          {
+            option.services.vertd = {
+              enable = mkEnableOption "vertd video converter service";
+              port = mkOption {
+                types = types.port;
+                description = "Port that vertd should listen to";
+                example = 8080;
+              };
+            };
+
+            config = mkIf cfg.enable {
+              systemd.services.vertd = {
+                description = "vertd video converter service";
+                wantedBy = [ "multi-user.target" ];
+                after = [ "network.target" ];
+                script = lib.getExe vertd;
+                serviceConfig = {
+                  User = "vertd";
+                  Group = "vertd";
+                  Restart = "always";
+                  RestartSec = 5;
+                  ExecStartPre = "mkdir -p /var/lib/vertd; chown vertd:vertd /var/lib/vertd";
+                  WorkingDirectory = "/var/lib/vertd";
+                };
+              };
+            };
+          };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -126,6 +126,12 @@
           };
 
           config = mkIf cfg.enable {
+            users.users.vertd = {
+              group = "vertd";
+              isSystemUser = true;
+            };
+            users.groups.vertd = { };
+
             systemd.services.vertd = {
               description = "vertd video converter service";
               wantedBy = [ "multi-user.target" ];
@@ -136,7 +142,8 @@
                 Group = "vertd";
                 Restart = "always";
                 RestartSec = 5;
-                ExecStartPre = "mkdir -p /var/lib/vertd; chown vertd:vertd /var/lib/vertd";
+                ExecStart = lib.getExe self.packages.${pkgs.system}.default;
+                StateDirectory = "vertd";
                 WorkingDirectory = "/var/lib/vertd";
               };
             };

--- a/flake.nix
+++ b/flake.nix
@@ -76,56 +76,6 @@
         );
       in
       {
-        checks = {
-          # Build the crate as part of `nix flake check` for convenience
-          inherit vertd;
-
-          # Run clippy (and deny all warnings) on the crate source,
-          # again, reusing the dependency artifacts from above.
-          #
-          # Note that this is done as a separate derivation so that
-          # we can block the CI if there are issues here, but not
-          # prevent downstream consumers from building our crate by itself.
-          vertd-clippy = craneLib.cargoClippy (
-            commonArgs
-            // {
-              inherit cargoArtifacts;
-              cargoClippyExtraArgs = "--all-targets -- --deny warnings";
-            }
-          );
-
-          vertd-doc = craneLib.cargoDoc (
-            commonArgs
-            // {
-              inherit cargoArtifacts;
-            }
-          );
-
-          # Check formatting
-          vertd-fmt = craneLib.cargoFmt {
-            inherit src;
-          };
-
-          vertd-toml-fmt = craneLib.taploFmt {
-            src = pkgs.lib.sources.sourceFilesBySuffices src [ ".toml" ];
-            # taplo arguments can be further customized below as needed
-            # taploExtraArgs = "--config ./taplo.toml";
-          };
-
-          # Run tests with cargo-nextest
-          # Consider setting `doCheck = false` on `vertd` if you do not want
-          # the tests to run twice
-          vertd-nextest = craneLib.cargoNextest (
-            commonArgs
-            // {
-              inherit cargoArtifacts;
-              partitions = 1;
-              partitionType = "count";
-              cargoNextestPartitionsExtraArgs = "--no-tests=pass";
-            }
-          );
-        };
-
         packages =
           {
             default = vertd;
@@ -143,9 +93,7 @@
           drv = vertd;
         };
 
-        devShells.default = craneLib.devShell {
-          checks = self.checks.${system};
-        };
+        devShells.default = craneLib.devShell { };
 
         nixosModules.default =
           { config, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -116,10 +116,10 @@
           cfg = config.services.vertd;
         in
         {
-          option.services.vertd = {
+          options.services.vertd = {
             enable = mkEnableOption "vertd video converter service";
             port = mkOption {
-              types = types.port;
+              type = types.port;
               description = "Port that vertd should listen to";
               example = 8080;
             };
@@ -130,7 +130,7 @@
               description = "vertd video converter service";
               wantedBy = [ "multi-user.target" ];
               after = [ "network.target" ];
-              script = lib.getExe self.packages.${pkgs.system}.vertd;
+              script = lib.getExe self.packages.${pkgs.system}.default;
               serviceConfig = {
                 User = "vertd";
                 Group = "vertd";


### PR DESCRIPTION
This will let NixOS systems easily install and use vertd. It exposes a nixos option `services.vertd`, that can add a systemd service and allows the port to be configured.

The flake also packages and exposes the executable itself.