### PR TITLE
Improve Dockerfile and GPU support on Linux 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,17 @@
-FROM nvidia/cuda:12.8.0-runtime-ubuntu24.04
+FROM rust:1.86 AS builder
 
-RUN apt-get update --allow-insecure-repositories && apt-get install -y \
-    curl \
-    build-essential \
-    libclang-dev \
-    vulkan-tools \
-    ffmpeg \
-    libssl-dev \
-    pkg-config \
-    && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
-WORKDIR /app
 COPY . .
 
-# build
-# RUN cargo build --release
-RUN $HOME/.cargo/bin/cargo build --release
+RUN cargo build --release
 
-CMD ["./target/release/vertd"]
+FROM nvidia/cuda:12.8.0-runtime-ubuntu24.04
+
+RUN apt-get update && apt-get install -y ffmpeg
+
+WORKDIR /app
+
+COPY --from=builder /build/target/release/vertd ./vertd
+
+CMD ["./vertd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 RUN cargo build --release
 
-FROM nvidia/cuda:12.8.0-runtime-ubuntu24.04
+FROM nvidia/cuda:12.8.0-base-ubuntu24.04
 
 RUN apt-get update && apt-get install -y ffmpeg
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,23 @@ RUN cargo build --release
 
 FROM nvidia/cuda:12.8.0-base-ubuntu24.04
 
-RUN apt-get update && apt-get install -y ffmpeg
-
 WORKDIR /app
+
+ARG DEBIAN_FRONTEND="noninteractive"
+
+ENV XDG_RUNTIME_DIR=/tmp
 
 COPY --from=builder /build/target/release/vertd ./vertd
 
-CMD ["./vertd"]
+RUN apt-get update && apt-get install -y \
+    ffmpeg \
+    mesa-va-drivers \
+    intel-media-va-driver \
+    vulkan-tools
+
+RUN rm -rf \
+    /tmp/* \
+    /var/lib/apt/lists/* \
+    /var/tmp/*
+
+ENTRYPOINT ["./vertd"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,14 @@ services:
       - WEBHOOK_PINGS=${WEBHOOK_PINGS}
     ports:
       - "${PORT:-24153}:${PORT:-24153}"
+
+    # For AMD/Intel GPUs, uncomment the "devices" section - then remove
+    # or comment out the "deploy" section used for NVIDIA GPUs.
+    #
+    # devices:
+    #   - /dev/dri
+
+    # For NVIDIA cards, simply keep the following section:
     deploy:
       resources:
         reservations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   vertd:
     build: .
+    image: vert-sh/vertd:latest
     environment:
       - PORT=${PORT:-24153}
       - WEBHOOK_URL=${WEBHOOK_URL}

--- a/src/converter/gpu.rs
+++ b/src/converter/gpu.rs
@@ -3,6 +3,7 @@ use log::warn;
 use std::fmt::{self, Display, Formatter};
 use tokio::process::Command;
 use wgpu::Instance;
+use std::env::consts;
 
 pub enum ConverterGPU {
     AMD,
@@ -32,10 +33,47 @@ impl ConverterGPU {
 
     pub fn encoder_priority(&self) -> Vec<&str> {
         match self {
-            ConverterGPU::AMD => vec!["amf"],
-            ConverterGPU::Intel => vec!["qsv"],
+            ConverterGPU::AMD => {
+                if consts::OS == "linux" {
+                    vec!["vaapi"]
+                } else {
+                    vec!["amf"]
+                }
+            },
+
+            ConverterGPU::Intel => {
+                if consts::OS == "linux" {
+                    vec!["vaapi"]
+                } else {
+                    vec!["qsv"]
+                }
+            },
+
             ConverterGPU::NVIDIA => vec!["nvenc"],
             ConverterGPU::Apple => vec!["videotoolbox"],
+        }
+    }
+
+    pub fn hwaccel_args(&self) -> &[&str] {
+        match self {
+            ConverterGPU::AMD => {
+                if consts::OS == "linux" {
+                    &["-hwaccel", "vaapi", "-hwaccel_output_format", "vaapi"]
+                } else {
+                    &["-hwaccel", "amf"]
+                }
+            },
+
+            ConverterGPU::Intel => {
+                if consts::OS == "linux" {
+                    &["-hwaccel", "vaapi", "-hwaccel_output_format", "vaapi"]
+                } else {
+                    &["-hwaccel", "qsv"]
+                }
+            },
+
+            ConverterGPU::NVIDIA => &["-hwaccel", "cuda"],
+            ConverterGPU::Apple => &["-hwaccel", "videotoolbox"],
         }
     }
 }
@@ -72,13 +110,34 @@ pub async fn get_gpu() -> anyhow::Result<ConverterGPU> {
     if info.name.contains("Apple") {
         return Ok(ConverterGPU::Apple);
     }
+
     match info.vendor {
         0x10DE => Ok(ConverterGPU::NVIDIA),
         0x1002 => Ok(ConverterGPU::AMD),
         0x8086 => Ok(ConverterGPU::Intel), // fun fact: intel's vendor id is 0x8086, presumably in reference to the intel 8086 processor
         0x106B | 0x0 => Ok(ConverterGPU::Apple),
-        0x10005 if is_docker().await => {
-            warn!("are you in a docker container? assuming NVIDIA, please open a PR and fix this if you're not.");
+        0x10000..=0x10007 if is_docker().await => {
+            // https://registry.khronos.org/vulkan/specs/latest/man/html/VkVendorId.html
+            // https://forums.developer.nvidia.com/t/wsl2-ubuntu-uses-llvmpipe-instead-of-nvidia-gpu-3090/319022
+            warn!("*******");
+            warn!("you're running vertd on a docker container, but no GPU was detected.");
+            warn!("this usually is because you're running Docker under WSL or because");
+            warn!("you are not passing the GPU device correctly.");
+            warn!("");
+            warn!("if this doesn't seem right, create an issue and provide this info:");
+            warn!("- adapter name: {}", info.name);
+            warn!("- adapter vendor: 0x{:X}", info.vendor);
+            warn!("- backend: {}", info.backend.to_str());
+            warn!("- device ID: {}", info.device);
+            warn!("- device type: {:#?}", info.device_type);
+            warn!("- driver: {}", info.driver);
+            warn!("- driver info: {}", info.driver_info);
+            warn!("- os: {}", consts::OS);
+            warn!("");
+            warn!("vertd will assume you have a NVIDIA GPU. if this isn't the case,");
+            warn!("conversions will likely fail.");
+            warn!("*******");
+
             Ok(ConverterGPU::NVIDIA)
         }
         _ => Err(anyhow!("unknown GPU vendor: 0x{:X}", info.vendor)),

--- a/src/converter/gpu.rs
+++ b/src/converter/gpu.rs
@@ -124,7 +124,8 @@ pub async fn get_gpu() -> anyhow::Result<ConverterGPU> {
             warn!("this usually is because you're running Docker under WSL or because");
             warn!("you are not passing the GPU device correctly.");
             warn!("");
-            warn!("if this doesn't seem right, create an issue and provide this info:");
+            warn!("if this doesn't seem right, make sure to provide the following info when");
+            warn!("asking for help:");
             warn!("- adapter name: {}", info.name);
             warn!("- adapter vendor: 0x{:X}", info.vendor);
             warn!("- backend: {}", info.backend.to_str());
@@ -132,7 +133,6 @@ pub async fn get_gpu() -> anyhow::Result<ConverterGPU> {
             warn!("- device type: {:#?}", info.device_type);
             warn!("- driver: {}", info.driver);
             warn!("- driver info: {}", info.driver_info);
-            warn!("- os: {}", consts::OS);
             warn!("");
             warn!("vertd will assume you have a NVIDIA GPU. if this isn't the case,");
             warn!("conversions will likely fail.");

--- a/src/converter/mod.rs
+++ b/src/converter/mod.rs
@@ -45,13 +45,7 @@ impl Converter {
             .await?;
         let args = args.iter().map(|s| s.as_str()).collect::<Vec<&str>>();
         let args = args.as_slice();
-
-        let gpu_args: &[&str] = match gpu {
-            gpu::ConverterGPU::AMD => &["-hwaccel", "amf"],
-            gpu::ConverterGPU::Intel => &["-hwaccel", "qsv"],
-            gpu::ConverterGPU::NVIDIA => &["-hwaccel", "cuda"],
-            gpu::ConverterGPU::Apple => &["-hwaccel", "videotoolbox"],
-        };
+        let gpu_args: &[&str] = gpu.hwaccel_args();
 
         let command = &[
             &["-hide_banner", "-loglevel", "error", "-progress", "pipe:1"],


### PR DESCRIPTION
* Use official Rust docker image for building vertd
* Use multi-stage build instead of keeping build tools on final image
* Use `base` CUDA image instead of `runtime`, which results in an image 6 GB lighter (from 7.1 GB to ~1.05 GB)
* Tried to improve the "assuming NVIDIA" message when running under Docker to be a bit more helpful?
* Updated vertd to prefer VAAPI over AMF/QSV when running under Linux
  - Should: close #3, close #10 and close #8
  - Also updated Docker image to include `intel-media-va-driver` and `mesa-va-drivers` for hardware acceleration on non-NVIDIA cards
* Specify image name on Docker Compose file

Tested with a RTX 3060 under WSL2 as well as an AMD Ryzen 9 7900's iGPU on Ubuntu Server 24.04 LTS. Both work fine, though Docker Desktop on Windows will always assume it has an NVIDIA GPU (this is the same behavior as before).