### PR TITLE
Fix NVIDIA GPU detection when running under Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,24 @@ WORKDIR /app
 ARG DEBIAN_FRONTEND="noninteractive"
 
 ENV XDG_RUNTIME_DIR=/tmp
+ENV NVIDIA_VISIBLE_DEVICES="all"
+ENV NVIDIA_DRIVER_CAPABILITIES="all"
 
 COPY --from=builder /build/target/release/vertd ./vertd
 
+# https://github.com/NVIDIA/nvidia-container-toolkit/issues/140#issuecomment-1927273909
 RUN apt-get update && apt-get install -y \
     ffmpeg \
     mesa-va-drivers \
     intel-media-va-driver \
-    vulkan-tools
+    libglvnd0 \
+    libgl1 \
+    libglx0 \
+    libegl1  \
+    libgles2  \
+    libxcb1-dev \
+    vulkan-tools \
+    mesa-utils
 
 RUN rm -rf \
     /tmp/* \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,16 +10,18 @@ services:
       - "${PORT:-24153}:${PORT:-24153}"
 
     # For AMD/Intel GPUs, uncomment the "devices" section - then remove
-    # or comment out the "deploy" section used for NVIDIA GPUs.
+    # or comment out the "deploy" section and the "runtime" string used
+    # for NVIDIA GPUs.
     #
     # devices:
     #   - /dev/dri
-
-    # For NVIDIA cards, simply keep the following section:
+    #
+    # For NVIDIA cards, keep the following section:
+    runtime: nvidia
     deploy:
       resources:
         reservations:
           devices:
             - driver: nvidia
               count: all
-              capabilities: [ gpu, video ]
+              capabilities: [ gpu ]


### PR DESCRIPTION
Before:

<img width="1158" height="433" alt="image" src="https://github.com/user-attachments/assets/eff27e88-db0d-4353-b41c-b3cb9c3072c4" />

After (duplicate logs seem to be because of docker/compose#13101?):

<img width="972" height="228" alt="image" src="https://github.com/user-attachments/assets/d801a329-85a5-4daa-8787-293bd02eb33e" />


Tested with a NVIDIA GeForce RTX 3060 12 GB under Arch Linux 6.15.8-arch1-1 with nvidia-dkms 575.64.05, cuda 12.9, nvidia-container-toolkit 1.17.8, docker 28.3.2 and docker compose 2.39.1