### PR TITLE
Upgrade actions/checkout from v2 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             format: ".exe"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Update actions/checkout from v2 to v4 in CI workflow

- Bump actions/checkout to v4 for improved performance and security
- Ensures compatibility with recent GitHub Actions runner updates

(AI used to write description i'm not good at writing good commit messages)