### PR TITLE
Fix "variable not set" Docker Compose warnings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     image: ghcr.io/vert-sh/vertd:latest
     environment:
       - PORT=${PORT:-24153}
-      - WEBHOOK_URL=${WEBHOOK_URL}
-      - WEBHOOK_PINGS=${WEBHOOK_PINGS}
-      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
-      - PUBLIC_URL=${PUBLIC_URL}
+      - WEBHOOK_URL=${WEBHOOK_URL:-}
+      - WEBHOOK_PINGS=${WEBHOOK_PINGS:-}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
+      - PUBLIC_URL=${PUBLIC_URL:-}
     ports:
       - "${PORT:-24153}:${PORT:-24153}"
 


### PR DESCRIPTION
Gets rid of these warnings:
```
WARN[0000] The "WEBHOOK_URL" variable is not set. Defaulting to a blank string. 
WARN[0000] The "WEBHOOK_PINGS" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ADMIN_PASSWORD" variable is not set. Defaulting to a blank string. 
WARN[0000] The "PUBLIC_URL" variable is not set. Defaulting to a blank string. 
```