### PR TITLE
feat: Add a way to define CORS origins using environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,8 @@ ADMIN_PASSWORD=supersecret
 
 # used for kept video access
 PUBLIC_URL=https://vertd.your-domain.here
+
+# CORS origins setup
+# Can either be "*" or comma separated origins: "https://origin1.com,https://origin2.com"
+# If not defined, fall back automatically to *
+CORS_ORIGINS=*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - WEBHOOK_PINGS=${WEBHOOK_PINGS}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - PUBLIC_URL=${PUBLIC_URL}
+      - CORS_ORIGINS=${CORS_ORIGINS:-*}
     ports:
       - "${PORT:-24153}:24153"
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -8,16 +8,75 @@ use crate::http::services::keep::keep;
 mod response;
 mod services;
 
+#[derive(Clone, Debug)]
+enum CorsConfig {
+    Any,
+    Specific(Vec<String>),
+}
+
+fn parse_cors(origins_raw: &str) -> CorsConfig {
+    let raw = origins_raw.trim();
+
+    if raw.is_empty() || raw == "*" {
+        return CorsConfig::Any;
+    }
+
+    let origins = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect::<Vec<_>>();
+
+    CorsConfig::Specific(origins)
+}
+
+fn build_cors(config: &CorsConfig) -> Cors {
+    match config {
+        CorsConfig::Any => Cors::default()
+            .allow_any_origin()
+            .allow_any_method()
+            .allow_any_header(),
+
+        CorsConfig::Specific(origins) => {
+            let mut cors = Cors::default().allow_any_method().allow_any_header();
+
+            for origin in origins {
+                cors = cors.allowed_origin(origin);
+            }
+
+            cors
+        }
+    }
+}
+
 pub async fn start_http() -> anyhow::Result<()> {
-    let server = HttpServer::new(|| {
-        App::new()
-            .wrap(
-                Cors::default()
-                    .allow_any_origin()
-                    .allow_any_method()
-                    .allow_any_header(),
-            )
-            .service(
+    let cors_origins = std::env::var("CORS_ORIGINS").unwrap_or_else(|_| "*".to_string());
+    let cors_config = parse_cors(&cors_origins);
+
+    match &cors_config {
+        CorsConfig::Any => info!("CORS: allow any origin (*)"),
+        CorsConfig::Specific(origins) => {
+            info!("CORS: allowed origins:");
+            for origin in origins {
+                info!("  - {}", origin);
+            }
+        }
+    }
+
+    let port = std::env::var("PORT").unwrap_or_else(|_| "24153".to_string());
+    if !port.chars().all(char::is_numeric) {
+        anyhow::bail!("PORT must be a number");
+    }
+    let ip = format!("0.0.0.0:{port}");
+    info!("http server starting on {}", ip);
+
+    HttpServer::new({
+        let cors_config = cors_config.clone(); // moved into the closure
+        move || {
+            let cors = build_cors(&cors_config);
+
+            App::new().wrap(cors).service(
                 web::scope("/api")
                     .service(upload)
                     .service(download)
@@ -25,13 +84,11 @@ pub async fn start_http() -> anyhow::Result<()> {
                     .service(version)
                     .service(keep),
             )
-    });
-    let port = std::env::var("PORT").unwrap_or_else(|_| "24153".to_string());
-    if !port.chars().all(char::is_numeric) {
-        anyhow::bail!("PORT must be a number");
-    }
-    let ip = format!("0.0.0.0:{}", port);
-    info!("http server listening on {}", ip);
-    server.bind(ip)?.run().await?;
+        }
+    })
+    .bind(ip)?
+    .run()
+    .await?;
+
     Ok(())
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -84,7 +84,7 @@ pub async fn start_http() -> anyhow::Result<()> {
     if !port.chars().all(char::is_numeric) {
         anyhow::bail!("PORT must be a number");
     }
-    let ip = format!("0.0.0.0:{port}");
+    let ip = format!("0.0.0.0:{}", port);
     info!("http server listening on {}", ip);
     server.bind(ip)?.run().await?;
     Ok(())

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -8,7 +8,7 @@ use crate::http::services::keep::keep;
 mod response;
 mod services;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 enum CorsConfig {
     Any,
     Specific(Vec<String>),

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -65,7 +65,7 @@ pub async fn start_http() -> anyhow::Result<()> {
     }
 
     let server = HttpServer::new({
-        let cors_config = cors_config.clone(); // moved into the closure
+        let cors_config = cors_config.clone();
         move || {
             let cors = build_cors(&cors_config);
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -64,14 +64,7 @@ pub async fn start_http() -> anyhow::Result<()> {
         }
     }
 
-    let port = std::env::var("PORT").unwrap_or_else(|_| "24153".to_string());
-    if !port.chars().all(char::is_numeric) {
-        anyhow::bail!("PORT must be a number");
-    }
-    let ip = format!("0.0.0.0:{port}");
-    info!("http server starting on {}", ip);
-
-    HttpServer::new({
+    let server = HttpServer::new({
         let cors_config = cors_config.clone(); // moved into the closure
         move || {
             let cors = build_cors(&cors_config);
@@ -85,10 +78,14 @@ pub async fn start_http() -> anyhow::Result<()> {
                     .service(keep),
             )
         }
-    })
-    .bind(ip)?
-    .run()
-    .await?;
+    });
 
+    let port = std::env::var("PORT").unwrap_or_else(|_| "24153".to_string());
+    if !port.chars().all(char::is_numeric) {
+        anyhow::bail!("PORT must be a number");
+    }
+    let ip = format!("0.0.0.0:{port}");
+    info!("http server listening on {}", ip);
+    server.bind(ip)?.run().await?;
     Ok(())
 }


### PR DESCRIPTION
Useful for self host instances.

It will log out the CORS origins defined at startup.

Example:

.env:
`CORS_ORIGINS=https://origin1.com,https://origin2.com`
logs:
```log
[2025-12-26T01:39:03Z INFO  vertd::http] CORS: allowed origins:
[2025-12-26T01:39:03Z INFO  vertd::http]   - https://origin1.com
[2025-12-26T01:39:03Z INFO  vertd::http]   - https://origin2.com
```
.env:
`CORS_ORIGINS=*`
logs:
```log
[2025-12-26T01:54:45Z INFO  vertd::http] CORS: allow any origin (*)
```
.env with no CORS_ORIGINS key
logs:
```log
[2025-12-26T01:55:55Z INFO  vertd::http] CORS: allow any origin (*)
```
CORS are enforced properly:
(running with CORS set to "example.com")
<img width="792" height="52" alt="image" src="https://github.com/user-attachments/assets/40f786da-5de2-4f02-ae8d-1d192f6cf70d" />

