### PR TITLE
feat: make vertd dual stack with ipv4 fallback instead of ipv4 only

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,3 +1,9 @@
+# note: vert-windows is actually a linux machine
+# it is the same machine and environment as vert-linux
+# the only reason it exists is to allow for parallel
+# builds on the same machine, to massively boost build
+# times -- gh actions only allows 1 job per machine
+
 name: Build and Release
 
 on:
@@ -31,25 +37,18 @@ jobs:
           - os: macos-latest
             friendly-name: mac-x86_64
             target: x86_64-apple-darwin
-          # Linux (github-hosted)
-          - os: ubuntu-latest
+          # Linux (self-hosted)
+          - os: vert-linux
             friendly-name: linux-x86_64
             target: x86_64-unknown-linux-gnu
-          # Windows Cross-Compile on Linux (github-hosted)
-          - os: ubuntu-latest
+          # Windows (self-hosted)
+          - os: vert-windows
             friendly-name: windows-x86_64
             target: x86_64-pc-windows-gnu
             format: ".exe"
-            use-mingw: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install MinGW (for Windows target)
-        if: matrix.use-mingw
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-mingw-w64-x86-64
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -67,10 +66,10 @@ jobs:
 
   release:
     name: Publish release
-    needs: build
-    runs-on: ubuntu-latest
+    needs: build # wait for all builds to finish
+    runs-on: vert-linux
     permissions:
-      contents: write
+      contents: write # necessary for releases?
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,9 +1,3 @@
-# note: vert-windows is actually a linux machine
-# it is the same machine and environment as vert-linux
-# the only reason it exists is to allow for parallel
-# builds on the same machine, to massively boost build
-# times -- gh actions only allows 1 job per machine
-
 name: Build and Release
 
 on:
@@ -37,18 +31,25 @@ jobs:
           - os: macos-latest
             friendly-name: mac-x86_64
             target: x86_64-apple-darwin
-          # Linux (self-hosted)
-          - os: vert-linux
+          # Linux (github-hosted)
+          - os: ubuntu-latest
             friendly-name: linux-x86_64
             target: x86_64-unknown-linux-gnu
-          # Windows (self-hosted)
-          - os: vert-windows
+          # Windows Cross-Compile on Linux (github-hosted)
+          - os: ubuntu-latest
             friendly-name: windows-x86_64
             target: x86_64-pc-windows-gnu
             format: ".exe"
+            use-mingw: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install MinGW (for Windows target)
+        if: matrix.use-mingw
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-mingw-w64-x86-64
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -66,10 +67,10 @@ jobs:
 
   release:
     name: Publish release
-    needs: build # wait for all builds to finish
-    runs-on: vert-linux
+    needs: build
+    runs-on: ubuntu-latest
     permissions:
-      contents: write # necessary for releases?
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rand = "0.9.0"
 rbtag = "0.3.0"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
+socket2 = "0.5"
 strum = "0.27.1"
 strum_macros = "0.27.1"
 thiserror = "2.0.11"

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -26,12 +26,45 @@ pub async fn start_http() -> anyhow::Result<()> {
                     .service(keep),
             )
     });
-    let port = std::env::var("PORT").unwrap_or_else(|_| "24153".to_string());
-    if !port.chars().all(char::is_numeric) {
-        anyhow::bail!("PORT must be a number");
-    }
-    let ip = format!("0.0.0.0:{}", port);
-    info!("http server listening on {}", ip);
-    server.bind(ip)?.run().await?;
+    let port_num: u16 = port.parse()?;
+    let addr_v6: SocketAddr = format!("[::]:{}", port_num).parse()?;
+
+    let listener = match Socket::new(Domain::IPV6, Type::STREAM, None)
+        .and_then(|s| { s.set_only_v6(false)?; s.set_reuse_address(true)?; s.bind(&addr_v6.into())?; s.listen(1024)?; Ok(s) })
+    {
+        Ok(socket) => {
+            info!("http server listening on {} (dual-stack v4/v6)", addr_v6);
+            socket.into()
+        }
+        Err(e) => {
+            warn!("dual-stack bind failed ({e}), falling back to IPv4-only 0.0.0.0:{port_num}");
+            let addr_v4 = format!("0.0.0.0:{}", port_num);
+            std::net::TcpListener::bind(&addr_v4)?
+        }
+    };
+
+    server.listen(listener)?.run().await?;
     Ok(())
 }
+
+
+
+    let port_num: u16 = port.parse()?;
+    let addr_v6: SocketAddr = format!("[::]:{}", port_num).parse()?;
+
+    let listener = match Socket::new(Domain::IPV6, Type::STREAM, None)
+        .and_then(|s| { s.set_only_v6(false)?; s.set_reuse_address(true)?; s.bind(&addr_v6.into())?; s.listen(1024)?; Ok(s) })
+    {
+        Ok(socket) => {
+            info!("http server listening on {} (dual-stack v4/v6)", addr_v6);
+            socket.into()
+        }
+        Err(e) => {
+            warn!("dual-stack bind failed ({e}), falling back to IPv4-only 0.0.0.0:{port_num}");
+            let addr_v4 = format!("0.0.0.0:{}", port_num);
+            std::net::TcpListener::bind(&addr_v4)?
+        }
+    };
+
+    server.listen(listener)?.run().await?;
+    Ok(())

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,6 +1,8 @@
 use actix_cors::Cors;
 use actix_web::{web, App, HttpServer};
-use log::info;
+use log::{info, warn};
+use socket2::{Domain, Protocol, Socket, Type};
+use std::net::SocketAddr;
 use services::{download::download, upload::upload, version::version, websocket::websocket};
 
 use crate::http::services::keep::keep;
@@ -8,7 +10,7 @@ use crate::http::services::keep::keep;
 mod response;
 mod services;
 
-pub async fn start_http() -> anyhow::Result<()> {
+pub async fn start_http(port: &str) -> anyhow::Result<()> {
     let server = HttpServer::new(|| {
         App::new()
             .wrap(
@@ -26,15 +28,23 @@ pub async fn start_http() -> anyhow::Result<()> {
                     .service(keep),
             )
     });
+
     let port_num: u16 = port.parse()?;
     let addr_v6: SocketAddr = format!("[::]:{}", port_num).parse()?;
 
-    let listener = match Socket::new(Domain::IPV6, Type::STREAM, None)
-        .and_then(|s| { s.set_only_v6(false)?; s.set_reuse_address(true)?; s.bind(&addr_v6.into())?; s.listen(1024)?; Ok(s) })
+    let listener = match Socket::new(Domain::IPV6, Type::STREAM, Some(Protocol::TCP))
+        .and_then(|s| { 
+            s.set_only_v6(false)?; 
+            s.set_reuse_address(true)?; 
+            s.bind(&addr_v6.into())?; 
+            s.listen(1024)?; 
+            Ok(s) 
+        })
     {
         Ok(socket) => {
             info!("http server listening on {} (dual-stack v4/v6)", addr_v6);
-            socket.into()
+            let std_listener: std::net::TcpListener = socket.into();
+            std_listener
         }
         Err(e) => {
             warn!("dual-stack bind failed ({e}), falling back to IPv4-only 0.0.0.0:{port_num}");
@@ -46,25 +56,3 @@ pub async fn start_http() -> anyhow::Result<()> {
     server.listen(listener)?.run().await?;
     Ok(())
 }
-
-
-
-    let port_num: u16 = port.parse()?;
-    let addr_v6: SocketAddr = format!("[::]:{}", port_num).parse()?;
-
-    let listener = match Socket::new(Domain::IPV6, Type::STREAM, None)
-        .and_then(|s| { s.set_only_v6(false)?; s.set_reuse_address(true)?; s.bind(&addr_v6.into())?; s.listen(1024)?; Ok(s) })
-    {
-        Ok(socket) => {
-            info!("http server listening on {} (dual-stack v4/v6)", addr_v6);
-            socket.into()
-        }
-        Err(e) => {
-            warn!("dual-stack bind failed ({e}), falling back to IPv4-only 0.0.0.0:{port_num}");
-            let addr_v4 = format!("0.0.0.0:{}", port_num);
-            std::net::TcpListener::bind(&addr_v4)?
-        }
-    };
-
-    server.listen(listener)?.run().await?;
-    Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,7 +213,8 @@ async fn main() -> anyhow::Result<()> {
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
         Err(e) => return Err(e.into()),
     }
-
+// Read port from environment variable, defaulting to "8080" if not set
+    let port = env::var("PORT").unwrap_or_else(|_| "8080".to_string());
     start_http().await?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,6 @@ async fn main() -> anyhow::Result<()> {
     }
 // Read port from environment variable, defaulting to "8080" if not set
     let port = env::var("PORT").unwrap_or_else(|_| "8080".to_string());
-    start_http().await?;
+    start_http(&port).await?;
     Ok(())
 }


### PR DESCRIPTION
Hi -- i made vertd dual stack capable with a strong ipv4 fallback.  I compiled this as a docker and ran it on my DS environemnt and then did docker exec curl with both -4 and -6 and confirmed that it is listening on both ipv4 and 6.  Nothing broken.

making vertd dual stack helps it work in more enviroments such as ipv6 only environments.  the strong fallback to ipv4 will make sure that it works in default mode of ipv4, since probably 99% of people are running this as ipv4 or DS.

I also made sure that everything compiles including the linux, macos, and win binaries.  THere were again no breaking changes.

thank you for your consideration.